### PR TITLE
Calling incorrect methods on left / right UIViewController's on state change

### DIFF
--- a/PaperFold/PaperFold/PaperFold/PaperFoldNavigationController.m
+++ b/PaperFold/PaperFold/PaperFold/PaperFoldNavigationController.m
@@ -54,18 +54,34 @@
 {
     if (paperFoldState==PaperFoldStateDefault)
     {
-        [self.leftViewController viewWillAppear:YES];
-        [self.leftViewController viewDidAppear:YES];
+        [self.rootViewController viewWillAppear:YES];
+        [self.rootViewController viewDidAppear:YES];
+        
+        if (self.rightViewController) {
+            [self.rightViewController viewWillDisappear:YES];
+            [self.rightViewController viewDidDisappear:YES];
+        }
+        
+        if (self.leftViewController) {
+            [self.leftViewController viewWillDisappear:YES];
+            [self.leftViewController viewDidDisappear:YES];
+        }
     }
     else if (paperFoldState==PaperFoldStateLeftUnfolded)
     {
-        [self.rootViewController viewWillAppear:YES];
-        [self.rootViewController viewDidAppear:YES];
+        [self.leftViewController viewWillAppear:YES];
+        [self.leftViewController viewDidAppear:YES];
+        
+        [self.rootViewController viewWillDisappear:YES];
+        [self.rootViewController viewDidDisappear:YES];
     }
     else if (paperFoldState==PaperFoldStateRightUnfolded)
     {
         [self.rightViewController viewWillAppear:YES];
         [self.rightViewController viewDidAppear:YES];
+        
+        [self.rootViewController viewWillDisappear:YES];
+        [self.rootViewController viewDidDisappear:YES];
     }
 }
 


### PR DESCRIPTION
Hi, I noticed that when changing paper fold states in the PaperFoldNavigationController, the nav controller was calling viewDidLoad / viewDidAppear on the incorrect UIViewControllers.

I've updated so it is calling the right UIViewControllers now.  

I have also added calls to viewWillDisapper and viewDidDisappear methods as I found my code also required them (and is good to have for completeness).  

Great little module btw, very impressed with your work!

Thanks
Jerrold 
