### PR TITLE
enabledDragging was being ignored when returning to previous state. .

### DIFF
--- a/PaperFold/PaperFold.xcodeproj/project.pbxproj
+++ b/PaperFold/PaperFold.xcodeproj/project.pbxproj
@@ -28,8 +28,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		F84CDB2A15E917C500DBA1C1 /* PaperFoldConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PaperFoldConstants.h; sourceTree = "<group>"; };
 		F82A503E1634C512005E7244 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
+		F84CDB2A15E917C500DBA1C1 /* PaperFoldConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PaperFoldConstants.h; sourceTree = "<group>"; };
 		F877BEF314E2B5F20076B1C6 /* FacingView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FacingView.h; sourceTree = "<group>"; };
 		F877BEF414E2B5F20076B1C6 /* FacingView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FacingView.m; sourceTree = "<group>"; };
 		F877BEF514E2B5F20076B1C6 /* FoldView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FoldView.h; sourceTree = "<group>"; };

--- a/PaperFold/PaperFold/PaperFold/PaperFoldView.h
+++ b/PaperFold/PaperFold/PaperFold/PaperFoldView.h
@@ -56,6 +56,8 @@ typedef void (^CompletionBlock)();
 // timer to animate folds after gesture ended
 // manual animation with NSTimer is required to sync the offset of the contentView, with the folding of views
 @property (nonatomic, strong) NSTimer *animationTimer;
+// step duration for animating a frame of paper-folding. Default value is 0.01;
+@property(nonatomic) CGFloat timerStepDuration;
 // the fold view on the left and bottom
 @property (nonatomic, strong) FoldView *bottomFoldView;
 // the fold view on the left

--- a/PaperFold/PaperFold/PaperFold/PaperFoldView.m
+++ b/PaperFold/PaperFold/PaperFold/PaperFoldView.m
@@ -351,7 +351,10 @@
         // use NSTimer to create manual animation to restore view
         
         //[self setPaperFoldState:PaperFoldStateDefault];
-        self.animationTimer = [NSTimer scheduledTimerWithTimeInterval:0.01 target:self selector:@selector(restoreView:) userInfo:nil repeats:YES];
+        if ((y > 0 && self.enableTopFoldDragging) || (y < 0 && self.enableBottomFoldDragging))
+        {
+            self.animationTimer = [NSTimer scheduledTimerWithTimeInterval:0.01 target:self selector:@selector(restoreView:) userInfo:nil repeats:YES];
+        }
         
 
     }
@@ -414,7 +417,10 @@
         // after panning completes
         // if offset does not exceed threshold
         // use NSTimer to create manual animation to restore view
-        self.animationTimer = [NSTimer scheduledTimerWithTimeInterval:0.01 target:self selector:@selector(restoreView:) userInfo:nil repeats:YES];
+        if ((x < 0 && self.enableLeftFoldDragging) || (x > 0 && self.enableLeftFoldDragging))
+        {
+            self.animationTimer = [NSTimer scheduledTimerWithTimeInterval:0.01 target:self selector:@selector(restoreView:) userInfo:nil repeats:YES];
+        }
         
         //self.paperFoldInitialPanDirection = PaperFoldInitialPanDirectionNone;
     }
@@ -786,23 +792,23 @@
     [self setIsAutomatedFolding:YES];
     if (state==PaperFoldStateDefault)
     {
-        self.animationTimer = [NSTimer scheduledTimerWithTimeInterval:0.01 target:self selector:@selector(restoreView:) userInfo:nil repeats:YES];
+        self.animationTimer = [NSTimer scheduledTimerWithTimeInterval:_timerStepDuration target:self selector:@selector(restoreView:) userInfo:nil repeats:YES];
     }
     else if (state==PaperFoldStateLeftUnfolded)
     {
-        self.animationTimer = [NSTimer scheduledTimerWithTimeInterval:0.01 target:self selector:@selector(unfoldLeftView:) userInfo:nil repeats:YES];
+        self.animationTimer = [NSTimer scheduledTimerWithTimeInterval:_timerStepDuration target:self selector:@selector(unfoldLeftView:) userInfo:nil repeats:YES];
     }
     else if (state==PaperFoldStateRightUnfolded)
     {
-        self.animationTimer = [NSTimer scheduledTimerWithTimeInterval:0.01 target:self selector:@selector(unfoldRightView:) userInfo:nil repeats:YES];
+        self.animationTimer = [NSTimer scheduledTimerWithTimeInterval:_timerStepDuration target:self selector:@selector(unfoldRightView:) userInfo:nil repeats:YES];
     }
     else if (state==PaperFoldStateTopUnfolded)
     {
-        self.animationTimer = [NSTimer scheduledTimerWithTimeInterval:0.01 target:self selector:@selector(unfoldTopView:) userInfo:nil repeats:YES];
+        self.animationTimer = [NSTimer scheduledTimerWithTimeInterval:_timerStepDuration target:self selector:@selector(unfoldTopView:) userInfo:nil repeats:YES];
     }
     else if (state==PaperFoldStateBottomUnfolded)
     {
-        self.animationTimer = [NSTimer scheduledTimerWithTimeInterval:0.01 target:self selector:@selector(unfoldBottomView:) userInfo:nil repeats:YES];
+        self.animationTimer = [NSTimer scheduledTimerWithTimeInterval:_timerStepDuration target:self selector:@selector(unfoldBottomView:) userInfo:nil repeats:YES];
     }
 }
 


### PR DESCRIPTION
Hello, 

Modification1:
- vertical pan handler -> enable top/bottom view drag was being ignored when return to the default stage.
- horizontal pan handler -> enable left/right view drag was being ignored when return to the default stage

Test case: 
1. Disable enable to drag
2. Set state to open a view, with the frame of the center view still partially revealed. 
3. On the center view, drag to return

Expected Outcome:

Can not drag

Actual Outcome: 

Dragging still works. 

Modification 2: 

I added a property to set the timer step for animations. . this controls the speed. . Perhaps it would be better to control the actual step amount, but this works for the values I wanted. . What do you think?

***\* Not in this pull request ***

Finally, we had another problem were out GestureRecognizers were broken after installing paper-fold. . . We fixed it, by simply disabling these. . . It would be good if we could stay in synch with the main branch. . . would you accept a pull request for this. . . perhaps simply disabling gesture recognizers or another solution? 
