### PR TITLE
Sets foldView hidden if contentView is visible and set pan direction in unfold left/right view

### DIFF
--- a/PaperFold/PaperFold/PaperFold/MultiFoldView.m
+++ b/PaperFold/PaperFold/PaperFold/MultiFoldView.m
@@ -99,6 +99,7 @@
             float foldWidth = frame.size.width/self.numberOfFolds;
             FoldView *foldView = [[FoldView alloc] initWithFrame:CGRectMake(foldWidth*i,0,foldWidth,frame.size.height) foldDirection:_foldDirection];
             [foldView setTag:FOLDVIEW_TAG+i];
+            [foldView setHidden:!self.contentViewHolder.hidden];
             [self addSubview:foldView];
         }
         else if (_foldDirection==FoldDirectionVertical)
@@ -106,6 +107,7 @@
             float foldHeight = frame.size.height/self.numberOfFolds;
             FoldView *foldView = [[FoldView alloc] initWithFrame:CGRectMake(0,foldHeight*(self.numberOfFolds-i)-foldHeight,frame.size.width,foldHeight) foldDirection:_foldDirection];
             [foldView setTag:FOLDVIEW_TAG+i];
+            [foldView setHidden:!self.contentViewHolder.hidden];
             [self addSubview:foldView];
         }
     }

--- a/PaperFold/PaperFold/PaperFold/PaperFoldView.m
+++ b/PaperFold/PaperFold/PaperFold/PaperFoldView.m
@@ -602,6 +602,8 @@
     [self.leftFoldView setHidden:NO];
     [self.rightFoldView setHidden:NO];
     
+    self.paperFoldInitialPanDirection=PaperFoldInitialPanDirectionHorizontal;
+
     CGAffineTransform transform = [self.contentView transform];
     float x = transform.tx + (self.leftFoldView.frame.size.width-transform.tx)/4;
     transform = CGAffineTransformMakeTranslation(x, 0);
@@ -661,6 +663,8 @@
     [self.leftFoldView setHidden:NO];
     [self.rightFoldView setHidden:NO];
     
+    self.paperFoldInitialPanDirection=PaperFoldInitialPanDirectionHorizontal;
+
     CGAffineTransform transform = [self.contentView transform];
     float x = transform.tx - (transform.tx+self.rightFoldView.frame.size.width)/8;
     transform = CGAffineTransformMakeTranslation(x, 0);


### PR DESCRIPTION
1. Fix for issue where multifold view sets new fold views visible although content view is visible, which results on unresponsive side view with fold views overlaid over content view.
2. Fixes issue where user could set pan direction to vertical by vertical gesture and if top & bottom folding is not enabled, horizontal panning wouldn't work after
