### PR TITLE
Fixed Fold not opening Left/Right after Vertical Swipe

### DIFF
--- a/PaperFold/PaperFold/PaperFold/PaperFoldView.m
+++ b/PaperFold/PaperFold/PaperFold/PaperFoldView.m
@@ -602,6 +602,8 @@
     [self.leftFoldView setHidden:NO];
     [self.rightFoldView setHidden:NO];
     
+    self.paperFoldInitialPanDirection = PaperFoldInitialPanDirectionHorizontal;
+    
     CGAffineTransform transform = [self.contentView transform];
     float x = transform.tx + (self.leftFoldView.frame.size.width-transform.tx)/4;
     transform = CGAffineTransformMakeTranslation(x, 0);
@@ -660,6 +662,8 @@
     [self.bottomFoldView setHidden:YES];
     [self.leftFoldView setHidden:NO];
     [self.rightFoldView setHidden:NO];
+    
+    self.paperFoldInitialPanDirection = PaperFoldInitialPanDirectionHorizontal;
     
     CGAffineTransform transform = [self.contentView transform];
     float x = transform.tx - (transform.tx+self.rightFoldView.frame.size.width)/8;


### PR DESCRIPTION
After a vertical swipe the left / right menu (horizontal) button would
not open anymore because the default is Vertical and there is no
setting it to Horizontal (added now) in the left / right ones.
